### PR TITLE
feat(bugfix): double operators with not oper

### DIFF
--- a/formatter/matlab_formatter.py
+++ b/formatter/matlab_formatter.py
@@ -168,7 +168,7 @@ class Formatter:
         # not (~ or !)
         m = self.p_not.match(part)
         if m:
-            return (m.group(1), m.group(2), m.group(3))
+            return (m.group(1) + ' ', m.group(2), m.group(3))
 
         # single operator (e.g. +, -, etc.)
         m = self.p_op.match(part)


### PR DESCRIPTION
Fixes wrong indentation when
double operators are used with the not
operator in a sentence.

without this commit, this valid code:
```
x = false || ~isempty(x)
```

would be indent to:
```
x = false ||~isempty(x)
```