### PR TITLE
add extraIndent option

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,5 +11,6 @@ Also usable as standalone without VScode.
 ## Extension Settings
 * `matlab-formatter.indentwidth`: Number of spaces used for indentation.
 * `matlab-formatter.separateBlocks`: Control whether newlines should be added before and after blocks such as for, if, while and so on.
+* `matlab-formatter.extraIndent`: Control whether code inside functions should be indented or not.
 * `matlab-formatter.pythonPath`: Optional custom path to python executable. Setting this options requires restarting vscode.
 * `matlab-formatter.formatterPath`: Optional custom path to matlab formatter. Setting this options requires restarting vscode.

--- a/extension.js
+++ b/extension.js
@@ -54,10 +54,11 @@ class MatlabFormatter {
             // let formatter = this.py +'"'+ __dirname + '/formatter/matlab_formatter.py"';
             let indentwidth = " --indentWidth=" + vscode.workspace.getConfiguration('matlab-formatter')['indentwidth'];
             let separateBlocks = " --separateBlocks=" + vscode.workspace.getConfiguration('matlab-formatter')['separateBlocks'];
+            let extraIndent = " --extraIndent=" + vscode.workspace.getConfiguration('matlab-formatter')['extraIndent'];
             let filename = ' -';
             let start = " --startLine=" + (range.start.line + 1);
             let end = " --endLine=" + (range.end.line + 1);
-            var p = cp.exec(this.py + " " + this.formatter + " " + filename + indentwidth + separateBlocks + start + end, (err, stdout, stderr) => {
+            var p = cp.exec(this.py + " " + this.formatter + " " + filename + indentwidth + separateBlocks + extraIndent + start + end, (err, stdout, stderr) => {
                 if (stdout != '') {
                     let toreplace = document.validateRange(new vscode.Range(range.start.line, 0, range.end.line + 1, 0));
                     var edit = [vscode.TextEdit.replace(toreplace, stdout)];

--- a/formatter/matlab_formatter.py
+++ b/formatter/matlab_formatter.py
@@ -92,11 +92,11 @@ class Formatter:
     iscomment=0
     separateBlocks=False
 
-    def __init__(self, indentwidth, separateBlocks):
+    def __init__(self, indentwidth, separateBlocks, extraIndent):
         self.istep=[]
         self.iwidth=indentwidth
         self.separateBlocks=separateBlocks
-
+        self.extraIndent=extraIndent
 
     def cleanLineFromStringsAndComments(self, line):
         split = self.extract_string_comment(line)
@@ -346,13 +346,18 @@ class Formatter:
         while wlines and not wlines[-1]:
             wlines.pop()
 
+        # remove extra indentation
+        if not(self.extraIndent):
+            wlines = [line if line[:self.iwidth] != self.iwidth*' '
+                      else line[self.iwidth:] for line in wlines]
+
         # write output
         for line in wlines:
             print(line)
 
 
 def main():
-    options = {'--startLine': 1, '--endLine': None, '--indentWidth': 4, '--separateBlocks': True}
+    options = {'--startLine': 1, '--endLine': None, '--indentWidth': 4, '--separateBlocks': True, '--extraIndent': True}
 
     if len(sys.argv) < 2:
         usage   = 'usage: matlab_formatter.py filename [options...]\n'
@@ -375,8 +380,9 @@ def main():
         start = options['--startLine']
         end = options['--endLine']
         sep = options['--separateBlocks']
+        extra = options['--extraIndent']
 
-        formatter = Formatter(indent, sep)
+        formatter = Formatter(indent, sep, extra)
         formatter.formatFile(sys.argv[1], start, end)
 
 if __name__ == '__main__':

--- a/package.json
+++ b/package.json
@@ -37,6 +37,11 @@
                     "default": true,
                     "description": "add newlines before and after blocks (for, if, etc.)"
                 },
+                "matlab-formatter.extraIndent": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "use extra indent for code inside functions"
+                },
                 "matlab-formatter.pythonPath": {
                     "type": "string",
                     "default": "",


### PR DESCRIPTION
Add an `extraIndent` option that allows to toggle the indentation for functions.
Hence, the *Classic* mode of MATLAB's smart indenting can be achieved ([see](https://blogs.mathworks.com/community/2009/05/11/keep-your-code-readable-with-smart-indenting/))

 `extraIndent = true`
```matlab
function out = demo(input)

    for n = 1:10
        out = input + 1;
    end

end
```

 `extraIndent = false`
```matlab
function out = demo(input)

for n = 1:10
    out = input + 1;
end

end
```