### PR TITLE
fix the problem in matlab_formatter.py

### DIFF
--- a/formatter/matlab_formatter.py
+++ b/formatter/matlab_formatter.py
@@ -304,6 +304,7 @@ class Formatter:
 
         m = re.match(self.ctrlend, line)
         if m:
+            global step
             if len(self.istep) > 0:
                 step = self.istep.pop()
             elif len(self.fstep) > 0:


### PR DESCRIPTION
in line 311 make step variable be a global variable to fix the problem in vscode

Original problem information in vscode is :
formatting failed Traceback (most recent call last): File "c:\Users\Sean\.vscode\extensions\affenwiesel.matlab-formatter-2.8.10\formatter\matlab_formatter.py", line 421, in <module> main() File "c:\Users\Sean\.vscode\extensions\affenwiesel.matlab-formatter-2.8.10\formatter\matlab_formatter.py", line 417, in main formatter.formatFile(sys.argv[1], start, end) File "c:\Users\Sean\.vscode\extensions\affenwiesel.matlab-formatter-2.8.10\formatter\matlab_formatter.py", line 349, in formatFile (offset, line) = self.formatLine(line) File "c:\Users\Sean\.vscode\extensions\affenwiesel.matlab-formatter-2.8.10\formatter\matlab_formatter.py", line 312, in formatLine return (-step, self.indent(-step) + m.group(2) + ' ' + self.format(m.group(3)).strip()) UnboundLocalError: local variable 'step' referenced before assignment
from matlab-formatter (extension module)