### PR TITLE
Adding inplace option and ignoring shebang line for Octave scripts and standalone installation hint

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,3 +17,20 @@ Also usable as standalone without VScode.
 
 ## Additional Options
 * The formatter can be switched off for selected lines by adding the comment `formatter ignore N`. For the next `N` lines, only the indentation will be fixed. Other than that, they will not be altered.
+
+## Standalone Installation
+
+On an Unix  system  the  formatter  can be as well  installed  as a  standalone
+command line application like this:
+
+```
+### Download the script into ~/.local/bin
+curl -fsSL -o ~/.local/bin/matlab-formatter \
+  https://raw.githubusercontent.com/mittelmark/matlab-formatter-vscode/refs/heads/master/formatter/matlab_formatter.py
+
+### Make the script executable
+chmod +x ~/.local/bin/matlab-formatter
+
+#### Verify the installation
+matlab-formatter
+```

--- a/formatter/matlab_formatter.py
+++ b/formatter/matlab_formatter.py
@@ -371,7 +371,7 @@ class Formatter:
             rlines = ['']
             return(rlines)
         # check for shebang
-        p = r'^#!'
+        p = r'#!.+'
         m = re.match(p,rlines[0])
         if m:
             nlines.append(rlines[0])

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "matlab-formatter",
     "displayName": "matlab-formatter",
     "description": "format matlab code",
-    "version": "2.11.0",
+    "version": "2.12.0",
     "publisher": "AffenWiesel",
     "engines": {
         "vscode": "^1.20.0"


### PR DESCRIPTION
Hello,

thanks for this nice and clean Python script.

I added an inplace option to allow to modify the current file in place, defaults to false to keep the current behavior. Further I check for a shebang line as Octave scripts come often with a Shebang as the very first line. Updated as well the README to give an hint on a standalone install. I am using this for instance for my [MicroEmacs](https://github.com/bjasspa/jasspa) editor to allow formatting. Would be nice if you can check and may be integrate this into your repository. 

Detlef